### PR TITLE
Enable linting in the repository

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,17 @@
+[MASTER]
+
+max-line-length=80
+# Make sure single / double quotes are used consistently within a module
+check-quote-consistency=yes
+
+# Set to 0 to auto-detect the number of processors available to use.
+jobs=0
+
+# Don't complain about "TODO", "FIXME", and "XXX" in the code
+disable=fixme
+
+# Only display messages, no aggregate report
+reports=no
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -1,0 +1,1 @@
+To run the linter, run `make lint`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+# Get all python files tracked by git
+LINT_FILES := $(shell git ls-files | grep '**.py' | xargs)
+
+lint:
+	pylint $(LINT_FILES)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+wheel==0.34.2
+astroid==2.4.1
+isort==4.3.21
+lazy-object-proxy==1.4.3
+mccabe==0.6.1
+pylint==2.5.2
+six==1.14.0
+toml==0.10.0
+typed-ast==1.4.1
+wrapt==1.12.1


### PR DESCRIPTION
- requirements.txt: install pylint and its dependencies
- .pylintrc: add configuration for pylint
- Makefile: utility for development; allows linting with `make lint`
- DEV_README.md: describes the above bullet