### PR TITLE
Remove python 3.5 from testing and linting

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We have decided to use f-strings, a way of string formatting in python.
This feature is only supported in pythons 3.6 an onwards.

See https://www.python.org/dev/peps/pep-0498/