### PR TITLE
Change most instances of list(map())

### DIFF
--- a/spotifython/player.py
+++ b/spotifython/player.py
@@ -463,7 +463,7 @@ class Player:
 
         try:
             devices = response_json['devices']
-            result = list(map(lambda elem: elem['id'], devices))
+            result = [elem['id'] for elem in devices]
         except KeyError:
             raise utils.SpotifyError(KEYSTRING)
 

--- a/spotifython/utils.py
+++ b/spotifython/utils.py
@@ -310,5 +310,4 @@ def separate(elems, filter_type):
 
 def map_ids(elems):
     """ Turn a list of objects into a list of spotify ids """
-    map_func = lambda elem: elem.spotify_id()
-    return list(map(map_func, elems))
+    return [elem.spotify_id() for elem in elems]

--- a/tests/help_lib.py
+++ b/tests/help_lib.py
@@ -62,6 +62,6 @@ def get_dummy_data(data_type: str,
 
     if to_obj:
         map_func = lambda elem: CLASS_MAPPINGS[data_type](None, elem)
-        result = list(map(map_func, result))
+        result = [map_func(elem) for elem in result]
 
     return result

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -283,9 +283,10 @@ class TestUser(unittest.TestCase):
 
         # Build some objects to check
         tracks = get_dummy_data(const.TRACKS)
-        tracks = list(map(lambda elem: Track(None, elem), tracks))
+        tracks = [Track(None, data) for data in tracks]
+
         albums = get_dummy_data(const.ALBUMS)
-        albums = list(map(lambda elem: Album(None, elem), albums))
+        albums = [Album(None, data) for data in albums]
 
         other = tracks + albums
         random.shuffle(other)


### PR DESCRIPTION
[func(elem) for elem in elems] is more readable than list(map(func, elems))