### PR TITLE
Remove BASE_URI duplicates in Playlist class

### DIFF
--- a/spotifython/playlist.py
+++ b/spotifython/playlist.py
@@ -52,8 +52,7 @@ class Playlist:
         Calls:
             GET /v1/playlists/{playlist_id}
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.SEARCH_GET_PLAYLIST % self.spotify_id()
+        endpoint = Endpoints.SEARCH_GET_PLAYLIST % self.spotify_id()
         response_json, status_code = utils.request(
             self._session,
             request_type='GET',
@@ -145,8 +144,7 @@ class Playlist:
         Calls endpoints:
             POST /v1/playlists/{playlist_id}/tracks
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST_TRACKS % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST_TRACKS % self.spotify_id()
         body = {}
         uris = []
         if isinstance(tracks, list):
@@ -194,8 +192,7 @@ class Playlist:
         Calls endpoints:
             PUT /v1/playlists/{playlist_id}
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST % self.spotify_id()
         if not isinstance(name, str):
             raise TypeError('The name must be a string')
         body = {}
@@ -225,8 +222,7 @@ class Playlist:
         Calls endpoints:
             PUT /v1/playlists/{playlist_id}
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST % self.spotify_id()
         if not isinstance(description, str):
             raise TypeError('The description must be a string')
         body = {}
@@ -257,8 +253,7 @@ class Playlist:
         Calls endpoints:
             PUT /v1/playlists/{playlist_id}
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST % self.spotify_id()
         body = {}
         if visibility not in [const.PUBLIC, const.PRIVATE,
                               const.PRIVATE_COLLAB]:
@@ -286,8 +281,7 @@ class Playlist:
         Calls endpoints:
             PUT /v1/playlists/{playlist_id}
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST_IMAGES % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST_IMAGES % self.spotify_id()
         response_json, status_code = utils.request(
             self._session,
             request_type='GET',
@@ -324,8 +318,7 @@ class Playlist:
         Calls endpoints:
             GET /v1/playlists/{playlist_id}/tracks
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST_TRACKS % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST_TRACKS % self.spotify_id()
         if not isinstance(start, int):
             raise TypeError('The start index must be an integer')
         original_start = start
@@ -373,8 +366,7 @@ class Playlist:
         Calls endpoints:
             DELETE /v1/playlists/{playlist_id}/tracks
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST_TRACKS % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST_TRACKS % self.spotify_id()
         body = {}
         body['tracks'] = []
         if tracks is not None and positions is None:
@@ -449,8 +441,7 @@ class Playlist:
         Calls endpoints:
             PUT /v1/playlists/{playlist_id}/tracks
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST_TRACKS % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST_TRACKS % self.spotify_id()
         if not isinstance(source_index, int):
             raise TypeError('The source index must be an integer')
         if not isinstance(dest_index, int):
@@ -498,8 +489,7 @@ class Playlist:
         Calls endpoints:
             PUT /v1/playlists/{playlist_id}/tracks
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST_TRACKS % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST_TRACKS % self.spotify_id()
         if not all([isinstance(track, Track) for track in tracks]):
             raise TypeError('All elements of tracks must be Track objects')
         body = {}
@@ -533,8 +523,7 @@ class Playlist:
         Calls endpoints:
             PUT /v1/playlists/{playlist_id}/images
         """
-        endpoint = Endpoints.BASE_URI
-        endpoint += Endpoints.PLAYLIST_IMAGES % self.spotify_id()
+        endpoint = Endpoints.PLAYLIST_IMAGES % self.spotify_id()
         if not any(ext in image for ext in ['.jpg', '.jpeg']):
             raise ValueError('The image must be a JPEG')
         body = []


### PR DESCRIPTION
utils.request() already prepends BASE_URI to the input endpoint, so
Playlist shouldn't also do that.