### PR TITLE
Change how Github actions tests our code

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,4 +32,4 @@ jobs:
         make lint
     - name: Test with unittest
       run: |
-        python -m unittest discover -s test
+        make test

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ lint-diff:
 	pylint $(DIFF_LINT_FILES)
 
 test:
-	python -m unittest
+	python3 -m unittest


### PR DESCRIPTION
Using `python3 -m unittest discover -s test` recursively finds tests and
runs extra things we don't want it to run. Just use `python3 -m
unittest` instead.