### PR TITLE
Tests for Session class

### DIFF
--- a/spotifython/album.py
+++ b/spotifython/album.py
@@ -37,6 +37,7 @@ class Album:
         """
         # Validate inputs
         if 'id' not in info:
+            print(type(info), type(info[0]))
             raise ValueError('Album id not in info')
 
         # TODO: need to make sure name is here.

--- a/spotifython/album.py
+++ b/spotifython/album.py
@@ -37,7 +37,6 @@ class Album:
         """
         # Validate inputs
         if 'id' not in info:
-            print(type(info), type(info[0]))
             raise ValueError('Album id not in info')
 
         # TODO: need to make sure name is here.

--- a/spotifython/session.py
+++ b/spotifython/session.py
@@ -1,7 +1,7 @@
 """ Session class. """
 
 # Standard library imports
-import math, copy
+import math
 
 # Local imports
 import spotifython.constants as const
@@ -159,12 +159,11 @@ class Session:
     ##################################
 
     # pylint: disable=too-many-arguments, too-many-locals, too-many-branches
+    # pylint: disable=too-many-statements
     # TODO: unfortunately this function has to be kind of long to accomodate the
     # logic required. Refactor this in the future.
-
     # TODO: 'optional field filters and operators' What are these? Provide
     #       a link and / or example.
-    # TODO: why are the enums search_type_x instead of just sp.ARTISTS etc.?
     def search(self,
                query,
                types,
@@ -358,7 +357,7 @@ class Session:
             new_remaining_types = list()
             for curr_type in remaining_types:
                 api_result_type = map_args_to_api_result[curr_type]
-                if response_json[api_result_type]['next'] != None:
+                if response_json[api_result_type]['next'] is not None:
                     new_remaining_types.append(curr_type)
             remaining_types = new_remaining_types
 

--- a/spotifython/session.py
+++ b/spotifython/session.py
@@ -1,7 +1,7 @@
 """ Session class. """
 
 # Standard library imports
-import math
+import math, copy
 
 # Local imports
 import spotifython.constants as const
@@ -179,13 +179,21 @@ class Session:
 
             types: type(s) of results to search for. One of:
 
-                - sp.SEARCH_TYPE_ALBUM,
-                - sp.SEARCH_TYPE_ARTIST
-                - sp.SEARCH_TYPE_PLAYLIST
-                - sp.SEARCH_TYPE_TRACK
+                - sp.ALBUMS
+                - sp.ARTISTS
+                - sp.PLAYLISTS
+                - sp.TRACKS
                 - List: can contain multiple of the above.
 
-            limit (int): the maximum number of results to return.
+            limit (int): the maximum number of results to return. If the limit
+                is None, will return up to the API-supported limit of 2000
+                results. Use this with caution as it will result in a very long
+                chain of queries!
+
+                Note: The limit is applied within each type, not on the total
+                response. For example, if the limit value is 3 and the search
+                is for both artists & albums, the response contains 3 artists
+                and 3 albums.
 
             market (str): a :term:`market code <Market>` or sp.TOKEN_REGION,
                 used for :term:`track relinking <Track Relinking>`. If None, no
@@ -231,8 +239,9 @@ class Session:
         if not isinstance(types, str) and \
             not all(isinstance(x, str) for x in types):
             raise TypeError('types should be str or a list of str')
-        if not isinstance(limit, int):
-            raise TypeError('limit should be int')
+        if (limit is not None and not isinstance(limit, int)) or \
+            (isinstance(limit, int) and limit < 1):
+            raise TypeError('limit should be None or int > 0')
         if market is not None and not isinstance(market, str):
             raise TypeError('market should be None or str')
         if include_external_audio is not None and \
@@ -251,6 +260,8 @@ class Session:
         for search_type_filter in types:
             if search_type_filter not in valid_types:
                 raise ValueError(f'search type {search_type_filter} invalid')
+        if limit is None:
+            limit = 2000
         if limit > 2000:
             raise ValueError('Spotify only supports up to 2000 search results.')
 
@@ -269,10 +280,10 @@ class Session:
         next_multiple = lambda num, mult: math.ceil(num / mult) * mult
         num_to_request = next_multiple(limit, const.SPOTIFY_PAGE_SIZE)
 
-
         # We want the singular search types, while our constants are plural
-        # search types in the argument for uniformity.
-        type_mapping = {
+        # search types in the argument for uniformity. The pagination objects
+        # use the plural types again, so a two way mapping is required.
+        map_args_to_api_call = {
             const.ALBUMS: 'album',
             const.ARTISTS: 'artist',
             const.PLAYLISTS: 'playlist',
@@ -280,19 +291,33 @@ class Session:
             const.SHOWS: 'show',
             const.EPISODES: 'episode',
         }
-        remaining_types = [type_mapping.get(s) for s in types]
+        map_args_to_api_result = {
+            'album': const.ALBUMS,
+            'artist': const.ARTISTS,
+            'playlist': const.PLAYLISTS,
+            'track': const.TRACKS,
+            'show': const.SHOWS,
+            'episode': const.EPISODES,
+        }
+        remaining_types = [map_args_to_api_call.get(s) for s in types]
 
         # Initialize SearchResult object
         result = {
-            type_mapping[const.ALBUMS]: list(),
-            type_mapping[const.ARTISTS]: list(),
-            type_mapping[const.PLAYLISTS]: list(),
-            type_mapping[const.TRACKS]: list(),
+            map_args_to_api_call[const.ALBUMS]: list(),
+            map_args_to_api_call[const.ARTISTS]: list(),
+            map_args_to_api_call[const.PLAYLISTS]: list(),
+            map_args_to_api_call[const.TRACKS]: list(),
         }
 
         # Unfortunately because each type can have a different amount of return
         # values, utils.paginate_get() is not suited for this call.
         for offset in range(0, num_to_request, const.SPOTIFY_PAGE_SIZE):
+            # This line simplifies the logic for cases where an extra request
+            # would otherwise be needed to hit the empty list check in the
+            # search responses.
+            if len(remaining_types) == 0:
+                break
+
             uri_params['type'] = ','.join(remaining_types)
             uri_params['limit'] = limit
             uri_params['offset'] = offset
@@ -312,17 +337,18 @@ class Session:
             # TODO: test what happens if unnecessary types are specified for
             # the given offsets against live api
             for curr_type in remaining_types:
-                items = response_json[curr_type]['items']
+                api_result_type = map_args_to_api_result[curr_type]
+                items = response_json[api_result_type]['items']
 
                 # Add items to accumulator
                 for item in items:
-                    if curr_type is type_mapping[const.ALBUMS]:
+                    if curr_type is map_args_to_api_call[const.ALBUMS]:
                         result.get(curr_type).append(Album(self, item))
-                    elif curr_type is type_mapping[const.ARTISTS]:
+                    elif curr_type is map_args_to_api_call[const.ARTISTS]:
                         result.get(curr_type).append(Artist(self, item))
-                    elif curr_type is type_mapping[const.PLAYLISTS]:
+                    elif curr_type is map_args_to_api_call[const.PLAYLISTS]:
                         result.get(curr_type).append(Playlist(self, item))
-                    elif curr_type is type_mapping[const.TRACKS]:
+                    elif curr_type is map_args_to_api_call[const.TRACKS]:
                         result.get(curr_type).append(Track(self, item))
                     else:
                         # Should never reach here, but here for safety!
@@ -331,7 +357,8 @@ class Session:
             # Only make necessary search queries
             new_remaining_types = list()
             for curr_type in remaining_types:
-                if response_json[curr_type]['next'] != 'null':
+                api_result_type = map_args_to_api_result[curr_type]
+                if response_json[api_result_type]['next'] != None:
                     new_remaining_types.append(curr_type)
             remaining_types = new_remaining_types
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -32,6 +32,49 @@ USER_ID = 'deadbeef'
 TOKEN = 'feebdaed'
 TOKEN1 = TOKEN + TOKEN
 
+SEARCH_LIMIT_1 = 100
+SEARCH_LIMIT_2 = 49
+
+expected_albums_json = get_dummy_data(
+    const.ALBUMS,
+    limit=SEARCH_LIMIT_1,
+)
+expected_albums = get_dummy_data(
+    const.ALBUMS,
+    limit=SEARCH_LIMIT_1,
+    to_obj=True
+)
+
+expected_artists_json = get_dummy_data(
+    const.ARTISTS,
+    limit=SEARCH_LIMIT_1,
+)
+expected_artists = get_dummy_data(
+    const.ARTISTS,
+    limit=SEARCH_LIMIT_1,
+    to_obj=True
+)
+
+expected_playlists_json = get_dummy_data(
+    const.PLAYLISTS,
+    limit=SEARCH_LIMIT_2,
+)
+expected_playlists = get_dummy_data(
+    const.PLAYLISTS,
+    limit=SEARCH_LIMIT_2,
+    to_obj=True
+)
+
+expected_tracks_json = get_dummy_data(
+    const.TRACKS,
+    limit=SEARCH_LIMIT_2,
+)
+expected_tracks = get_dummy_data(
+    const.TRACKS,
+    limit=SEARCH_LIMIT_2,
+    to_obj=True
+)
+
 class TestArtist(unittest.TestCase):
 
     # This function is called before every test_* function. Anything that is
@@ -77,23 +120,137 @@ class TestArtist(unittest.TestCase):
     def test_reauthenticate(self):
         session = Session(TOKEN)
         session.reauthenticate(TOKEN1)
-        session_1 = Session(TOKEN_1)
+        session_1 = Session(TOKEN1)
         self.assertFalse(session == session_1)
 
     # Test token, timeout
     def test_getters(self):
         session = Session(TOKEN)
         session_1 = Session(TOKEN1)
-        self.assertEqual(token(session), token(session))
-        self.assertFalse(token(session) == token(session_1))
+        self.assertEqual(session.token(), session.token())
+        self.assertFalse(session.token() == session_1.token())
         # Using default timeout
-        self.assertEqual(timeout(session), timeout(session))
-        self.assertEqual(timeout(session) == timeout(session_1))
+        self.assertEqual(session.timeout(), session.timeout())
+        self.assertEqual(session.timeout(), session_1.timeout())
 
     # Test search
-    @unittest.skip('Not yet implemented')
     def test_search(self):
-        self.assertTrue(False)
+        session = Session(TOKEN)
+        self.request_mock.side_effect = [
+            (
+                {
+                    'albums': {
+                        'href': 'href_uri',
+                        'items': expected_albums_json[:50],
+                        'limit': 50,
+                        'next': 'next_here',
+                        'offset': 0,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_1,
+                    },
+                    'artists': {
+                        'href': 'href_uri',
+                        'items': expected_artists_json[:50],
+                        'limit': 50,
+                        'next': 'next_here',
+                        'offset': 0,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_1,
+                    },
+                    'playlists': {
+                        'href': 'href_uri',
+                        'items': expected_playlists_json[:50],
+                        'limit': 50,
+                        'next': 'next_here',
+                        'offset': 0,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_2,
+                    },
+                    'tracks': {
+                        'href': 'href_uri',
+                        'items': expected_tracks_json[:50],
+                        'limit': 50,
+                        'next': 'next_here',
+                        'offset': 0,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_2,
+                    }
+                },
+                200
+            ),
+            (
+                {
+                    'albums': {
+                        'href': 'href_uri',
+                        'items': expected_albums_json[50:100],
+                        'limit': 50,
+                        'next': 'next_here',
+                        'offset': 50,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_1,
+                    },
+                    'artists': {
+                        'href': 'href_uri',
+                        'items': expected_artists_json[50:100],
+                        'limit': 50,
+                        'next': 'next_here',
+                        'offset': 50,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_1,
+                    },
+                    'playlists': {
+                        'href': 'href_uri',
+                        'items': [],
+                        'limit': 50,
+                        'next': None,
+                        'offset': 50,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_2,
+                    },
+                    'tracks': {
+                        'href': 'href_uri',
+                        'items': [],
+                        'limit': 50,
+                        'next': None,
+                        'offset': 50,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_2,
+                    }
+                },
+                200
+            ),
+            (
+                {
+                    'albums': {
+                        'href': 'href_uri',
+                        'items': [],
+                        'limit': 50,
+                        'next': None,
+                        'offset': 100,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_1,
+                    },
+                    'artists': {
+                        'href': 'href_uri',
+                        'items': [],
+                        'limit': 50,
+                        'next': None,
+                        'offset': 100,
+                        'previous': 'previous_uri',
+                        'total': SEARCH_LIMIT_1,
+                    }
+                },
+                200
+            )
+        ]
+        search_result = session.search(query="dummy_query",
+                                      types=[const.ARTISTS, const.ALBUMS, const.PLAYLISTS, const.TRACKS],
+                                      limit=None
+                                      )
+        self.assertEqual(search_result.albums(), expected_albums)
+        self.assertEqual(search_result.artists(), expected_artists)
+        self.assertEqual(search_result.playlists(), expected_playlists)
+        self.assertEqual(search_result.tracks(), expected_tracks)
 
     # Test get_albums
     @unittest.skip('Not yet implemented')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -40,10 +40,6 @@ class TestArtist(unittest.TestCase):
     # This function is called before every test_* function. Anything that is
     # needed by every test_* function should be stored in "self" here.
     def setUp(self):
-        # Note: since we're mocking Spotify and never actually using the token,
-        # we can put any string here for the token.
-        self.session = Session(TOKEN)
-
         # Mock the sp._request method so that we never actually reach Spotify
         self.patcher = patch.object(utils, 'request', autospec=True)
 
@@ -54,35 +50,50 @@ class TestArtist(unittest.TestCase):
         # Create the actual mock object
         self.request_mock = self.patcher.start()
 
-        # Logging can be added using print() now
-        self.stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(self.stream_handler)
-
     # This function is called after every test_* function. Use it to clean up
     # any resources initialized by the setUp function. Only include it if you
     # actually need to clean up resources.
     def tearDown(self):
-        logger.removeHandler(self.stream_handler)
+        pass
 
     # Test __str__, __repr__
-    @unittest.skip('Not yet implemented')
     def test_str_overloads(self):
-        self.assertTrue(self.session == self.session)
+        # Note: since we're mocking Spotify and never actually using the token,
+        # we can put any string here for the token.
+        session = Session(TOKEN)
+        session_1 = Session(TOKEN + TOKEN)
+        self.assertEqual(str(session), str(session))
+        self.assertFalse(str(session) == str(session_1))
+        self.assertEqual(repr(session), repr(session))
+        self.assertFalse(repr(session) == repr(session_1))
 
     # Test __eq__, __ne__, __hash__
-    @unittest.skip('Not yet implemented')
     def test_equality_overloads(self):
-        self.assertTrue(False)
+        session = Session(TOKEN)
+        session_1 = Session(TOKEN + TOKEN)
+        self.assertEqual(session, session)
+        self.assertFalse(session == session_1)
+        self.assertEqual(hash(session), hash(session))
+        self.assertFalse(hash(session) == hash(session_1))
 
     # Test reauthenticate
-    @unittest.skip('Not yet implemented')
     def test_reauthenticate(self):
-        self.assertTrue(False)
+        TOKEN_1 = TOKEN + TOKEN
+        session = Session(TOKEN)
+        session.reauthenticate(TOKEN)
+        session_1 = Session(TOKEN_1)
+        self.assertFalse(session == session_1)
 
     # Test token, timeout
-    @unittest.skip('Not yet implemented')
     def test_getters(self):
-        self.assertTrue(False)
+        TOKEN_1 = TOKEN + TOKEN
+        session = Session(TOKEN)
+        session_1 = Session(TOKEN1)
+        self.assertEqual(token(session), token(session))
+        self.assertFalse(token(session) == token(session_1))
+        # Using default timeout
+        self.assertEqual(timeout(session), timeout(session))
+        self.assertEqual(timeout(session) == timeout(session_1))
 
     # Test search
     @unittest.skip('Not yet implemented')
@@ -126,4 +137,4 @@ from spotifython.player import Player
 from spotifython.playlist import Playlist
 from spotifython.track import Track
 from spotifython.user import User
-from spotifython.session import Session as sp
+from spotifython.session import Session

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -22,25 +22,30 @@ Last updated: May 30, 2020
 # Standard library imports
 import unittest
 from unittest.mock import patch
+import sys, logging
+
+logger = logging.getLogger()
+logger.level = logging.DEBUG
 
 # Local imports
 from tests.help_lib import get_dummy_data
 import spotifython.constants as const
+import spotifython.utils as utils
 
 USER_ID = 'deadbeef'
 TOKEN = 'feebdaed'
 
-class TestSession(unittest.TestCase):
+class TestArtist(unittest.TestCase):
 
     # This function is called before every test_* function. Anything that is
     # needed by every test_* function should be stored in "self" here.
     def setUp(self):
         # Note: since we're mocking Spotify and never actually using the token,
         # we can put any string here for the token.
-        self.session = sp(TOKEN)
+        self.session = Session(TOKEN)
 
         # Mock the sp._request method so that we never actually reach Spotify
-        self.patcher = patch.object(sp, '_request', autospec=True)
+        self.patcher = patch.object(utils, 'request', autospec=True)
 
         # Add cleanup to unmock sp._request. Cleanup always called after trying
         # to execute a test, even if the test or setUp errors out / fails.
@@ -49,11 +54,15 @@ class TestSession(unittest.TestCase):
         # Create the actual mock object
         self.request_mock = self.patcher.start()
 
+        # Logging can be added using print() now
+        self.stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(self.stream_handler)
+
     # This function is called after every test_* function. Use it to clean up
     # any resources initialized by the setUp function. Only include it if you
     # actually need to clean up resources.
     def tearDown(self):
-        pass
+        logger.removeHandler(self.stream_handler)
 
     # Test __str__, __repr__
     @unittest.skip('Not yet implemented')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -34,6 +34,7 @@ TOKEN1 = TOKEN + TOKEN
 
 SEARCH_LIMIT_1 = 100
 SEARCH_LIMIT_2 = 49
+SEARCH_LIMIT_USERS = 5
 
 expected_albums_json = get_dummy_data(
     const.ALBUMS,
@@ -72,6 +73,16 @@ expected_tracks_json = get_dummy_data(
 expected_tracks = get_dummy_data(
     const.TRACKS,
     limit=SEARCH_LIMIT_2,
+    to_obj=True
+)
+
+expected_users_json = get_dummy_data(
+    const.USERS,
+    limit=SEARCH_LIMIT_USERS,
+)
+expected_users = get_dummy_data(
+    const.USERS,
+    limit=SEARCH_LIMIT_USERS,
     to_obj=True
 )
 
@@ -342,10 +353,26 @@ class TestArtist(unittest.TestCase):
         )
         self.assertEqual(tracks, expected_tracks)
 
-    # Test get_users, current_user
-    @unittest.skip('Not yet implemented')
+    # Test get_users
     def test_get_users(self):
-        self.assertTrue(False)
+        session = Session(TOKEN)
+        self.request_mock.side_effect = [
+            (
+                expected_users_json[i],
+                200
+            ) for i in range(SEARCH_LIMIT_USERS)
+        ]
+        users = session.get_users(
+            list(
+                map(lambda x: x['id'], expected_users_json)
+            )
+        )
+        self.assertEqual(users, expected_users)
+
+    # Test current_user
+    @unittest.skip('Not yet implemented')
+    def test_current_user(self):
+        pass
 
     # Test get_playlists
     @unittest.skip('Not yet implemented')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,25 +19,30 @@ Last updated: May 30, 2020
 # Standard library imports
 import unittest
 from unittest.mock import patch
+import sys, logging
+
+logger = logging.getLogger()
+logger.level = logging.DEBUG
 
 # Local imports
 from tests.help_lib import get_dummy_data
 import spotifython.constants as const
+import spotifython.utils as utils
 
 USER_ID = 'deadbeef'
 TOKEN = 'feebdaed'
 
-class TestSession(unittest.TestCase):
+class TestArtist(unittest.TestCase):
 
     # This function is called before every test_* function. Anything that is
     # needed by every test_* function should be stored in "self" here.
     def setUp(self):
         # Note: since we're mocking Spotify and never actually using the token,
         # we can put any string here for the token.
-        self.session = sp(TOKEN)
+        self.session = Session(TOKEN)
 
         # Mock the sp._request method so that we never actually reach Spotify
-        self.patcher = patch.object(sp, '_request', autospec=True)
+        self.patcher = patch.object(utils, 'request', autospec=True)
 
         # Add cleanup to unmock sp._request. Cleanup always called after trying
         # to execute a test, even if the test or setUp errors out / fails.
@@ -46,11 +51,15 @@ class TestSession(unittest.TestCase):
         # Create the actual mock object
         self.request_mock = self.patcher.start()
 
+        # Logging can be added using print() now
+        self.stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(self.stream_handler)
+
     # This function is called after every test_* function. Use it to clean up
     # any resources initialized by the setUp function. Only include it if you
     # actually need to clean up resources.
     def tearDown(self):
-        pass
+        logger.removeHandler(self.stream_handler)
 
     # Test __str__, __repr__
     @unittest.skip('Not yet implemented')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -319,9 +319,28 @@ class TestArtist(unittest.TestCase):
         self.assertEqual(artists, expected_artists)
 
     # Test get_tracks
-    @unittest.skip('Not yet implemented')
     def test_get_tracks(self):
-        self.assertTrue(False)
+        session = Session(TOKEN)
+        self.request_mock.side_effect = [
+            (
+                {
+                    "tracks" : expected_tracks_json[0:50]
+                },
+                200
+            ),
+            (
+                {
+                    "tracks" : expected_tracks_json[50:100]
+                },
+                200
+            )
+        ]
+        tracks = session.get_tracks(
+            list(
+                map(lambda x: x['id'], expected_tracks_json)
+            )
+        )
+        self.assertEqual(tracks, expected_tracks)
 
     # Test get_users, current_user
     @unittest.skip('Not yet implemented')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -32,47 +32,49 @@ USER_ID = 'deadbeef'
 TOKEN = 'feebdaed'
 TOKEN1 = TOKEN + TOKEN
 
-SEARCH_LIMIT_1 = 100
-SEARCH_LIMIT_2 = 49
+SEARCH_LIMIT_ALBUMS = 100
+SEARCH_LIMIT_ARTISTS = 100
+SEARCH_LIMIT_PLAYLISTS = 23
+SEARCH_LIMIT_TRACKS = 59
 SEARCH_LIMIT_USERS = 5
 
 expected_albums_json = get_dummy_data(
     const.ALBUMS,
-    limit=SEARCH_LIMIT_1,
+    limit=SEARCH_LIMIT_ALBUMS,
 )
 expected_albums = get_dummy_data(
     const.ALBUMS,
-    limit=SEARCH_LIMIT_1,
+    limit=SEARCH_LIMIT_ALBUMS,
     to_obj=True
 )
 
 expected_artists_json = get_dummy_data(
     const.ARTISTS,
-    limit=SEARCH_LIMIT_1,
+    limit=SEARCH_LIMIT_ARTISTS,
 )
 expected_artists = get_dummy_data(
     const.ARTISTS,
-    limit=SEARCH_LIMIT_1,
+    limit=SEARCH_LIMIT_ARTISTS,
     to_obj=True
 )
 
 expected_playlists_json = get_dummy_data(
     const.PLAYLISTS,
-    limit=SEARCH_LIMIT_2,
+    limit=SEARCH_LIMIT_PLAYLISTS,
 )
 expected_playlists = get_dummy_data(
     const.PLAYLISTS,
-    limit=SEARCH_LIMIT_2,
+    limit=SEARCH_LIMIT_PLAYLISTS,
     to_obj=True
 )
 
 expected_tracks_json = get_dummy_data(
     const.TRACKS,
-    limit=SEARCH_LIMIT_2,
+    limit=SEARCH_LIMIT_PLAYLISTS,
 )
 expected_tracks = get_dummy_data(
     const.TRACKS,
-    limit=SEARCH_LIMIT_2,
+    limit=SEARCH_LIMIT_PLAYLISTS,
     to_obj=True
 )
 
@@ -157,7 +159,7 @@ class TestArtist(unittest.TestCase):
                         'next': 'next_here',
                         'offset': 0,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_1,
+                        'total': SEARCH_LIMIT_ALBUMS,
                     },
                     'artists': {
                         'href': 'href_uri',
@@ -166,7 +168,7 @@ class TestArtist(unittest.TestCase):
                         'next': 'next_here',
                         'offset': 0,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_1,
+                        'total': SEARCH_LIMIT_ARTISTS,
                     },
                     'playlists': {
                         'href': 'href_uri',
@@ -175,7 +177,7 @@ class TestArtist(unittest.TestCase):
                         'next': 'next_here',
                         'offset': 0,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_2,
+                        'total': SEARCH_LIMIT_PLAYLISTS,
                     },
                     'tracks': {
                         'href': 'href_uri',
@@ -184,7 +186,7 @@ class TestArtist(unittest.TestCase):
                         'next': 'next_here',
                         'offset': 0,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_2,
+                        'total': SEARCH_LIMIT_TRACKS,
                     }
                 },
                 200
@@ -198,7 +200,7 @@ class TestArtist(unittest.TestCase):
                         'next': 'next_here',
                         'offset': 50,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_1,
+                        'total': SEARCH_LIMIT_ALBUMS,
                     },
                     'artists': {
                         'href': 'href_uri',
@@ -207,7 +209,7 @@ class TestArtist(unittest.TestCase):
                         'next': 'next_here',
                         'offset': 50,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_1,
+                        'total': SEARCH_LIMIT_ARTISTS,
                     },
                     'playlists': {
                         'href': 'href_uri',
@@ -216,7 +218,7 @@ class TestArtist(unittest.TestCase):
                         'next': None,
                         'offset': 50,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_2,
+                        'total': SEARCH_LIMIT_PLAYLISTS,
                     },
                     'tracks': {
                         'href': 'href_uri',
@@ -225,7 +227,7 @@ class TestArtist(unittest.TestCase):
                         'next': None,
                         'offset': 50,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_2,
+                        'total': SEARCH_LIMIT_TRACKS,
                     }
                 },
                 200
@@ -239,7 +241,7 @@ class TestArtist(unittest.TestCase):
                         'next': None,
                         'offset': 100,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_1,
+                        'total': SEARCH_LIMIT_ALBUMS,
                     },
                     'artists': {
                         'href': 'href_uri',
@@ -248,7 +250,7 @@ class TestArtist(unittest.TestCase):
                         'next': None,
                         'offset': 100,
                         'previous': 'previous_uri',
-                        'total': SEARCH_LIMIT_1,
+                        'total': SEARCH_LIMIT_ARTISTS,
                     }
                 },
                 200
@@ -375,9 +377,21 @@ class TestArtist(unittest.TestCase):
         pass
 
     # Test get_playlists
-    @unittest.skip('Not yet implemented')
     def test_get_playlists(self):
-        self.assertTrue(False)
+        session = Session(TOKEN)
+        self.request_mock.side_effect = [
+            (
+                expected_playlists_json[i],
+                200
+            ) for i in range(SEARCH_LIMIT_PLAYLISTS)
+        ]
+
+        playlists = session.get_playlists(
+            list(
+                map(lambda x: x['id'], expected_playlists_json)
+            )
+        )
+        self.assertEqual(playlists, expected_playlists)
 
 # This allows the tests to be executed
 if __name__ == '__main__':

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -22,10 +22,6 @@ Last updated: May 30, 2020
 # Standard library imports
 import unittest
 from unittest.mock import patch
-import sys, logging
-
-logger = logging.getLogger()
-logger.level = logging.DEBUG
 
 # Local imports
 from tests.help_lib import get_dummy_data
@@ -34,6 +30,7 @@ import spotifython.utils as utils
 
 USER_ID = 'deadbeef'
 TOKEN = 'feebdaed'
+TOKEN1 = TOKEN + TOKEN
 
 class TestArtist(unittest.TestCase):
 
@@ -61,7 +58,7 @@ class TestArtist(unittest.TestCase):
         # Note: since we're mocking Spotify and never actually using the token,
         # we can put any string here for the token.
         session = Session(TOKEN)
-        session_1 = Session(TOKEN + TOKEN)
+        session_1 = Session(TOKEN1)
         self.assertEqual(str(session), str(session))
         self.assertFalse(str(session) == str(session_1))
         self.assertEqual(repr(session), repr(session))
@@ -70,7 +67,7 @@ class TestArtist(unittest.TestCase):
     # Test __eq__, __ne__, __hash__
     def test_equality_overloads(self):
         session = Session(TOKEN)
-        session_1 = Session(TOKEN + TOKEN)
+        session_1 = Session(TOKEN1)
         self.assertEqual(session, session)
         self.assertFalse(session == session_1)
         self.assertEqual(hash(session), hash(session))
@@ -78,15 +75,13 @@ class TestArtist(unittest.TestCase):
 
     # Test reauthenticate
     def test_reauthenticate(self):
-        TOKEN_1 = TOKEN + TOKEN
         session = Session(TOKEN)
-        session.reauthenticate(TOKEN)
+        session.reauthenticate(TOKEN1)
         session_1 = Session(TOKEN_1)
         self.assertFalse(session == session_1)
 
     # Test token, timeout
     def test_getters(self):
-        TOKEN_1 = TOKEN + TOKEN
         session = Session(TOKEN)
         session_1 = Session(TOKEN1)
         self.assertEqual(token(session), token(session))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -295,9 +295,28 @@ class TestArtist(unittest.TestCase):
         self.assertEqual(albums, expected_albums)
 
     # Test get_artists
-    @unittest.skip('Not yet implemented')
     def test_get_artists(self):
-        self.assertTrue(False)
+        session = Session(TOKEN)
+        self.request_mock.side_effect = [
+            (
+                {
+                    "artists" : expected_artists_json[0:50]
+                },
+                200
+            ),
+            (
+                {
+                    "artists" : expected_artists_json[50:100]
+                },
+                200
+            )
+        ]
+        artists = session.get_artists(
+            list(
+                map(lambda x: x['id'], expected_artists_json)
+            )
+        )
+        self.assertEqual(artists, expected_artists)
 
     # Test get_tracks
     @unittest.skip('Not yet implemented')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -372,9 +372,12 @@ class TestArtist(unittest.TestCase):
         self.assertEqual(users, expected_users)
 
     # Test current_user
-    @unittest.skip('Not yet implemented')
     def test_current_user(self):
-        pass
+        session = Session(TOKEN)
+        self.request_mock.return_value = (expected_users_json[0], 200)
+        expected_user = User(session, info=expected_users_json[0])
+        user = session.current_user()
+        self.assertEqual(user, expected_user)
 
     # Test get_playlists
     def test_get_playlists(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -91,7 +91,7 @@ expected_users = get_dummy_data(
 class TestArtist(unittest.TestCase):
 
     # This function is called before every test_* function. Anything that is
-    # needed by every test_* function should be stored in "self" here.
+    # needed by every test_* function should be stored in 'self' here.
     def setUp(self):
         # Mock the sp._request method so that we never actually reach Spotify
         self.patcher = patch.object(utils, 'request', autospec=True)
@@ -256,10 +256,15 @@ class TestArtist(unittest.TestCase):
                 200
             )
         ]
-        search_result = session.search(query="dummy_query",
-                                      types=[const.ARTISTS, const.ALBUMS, const.PLAYLISTS, const.TRACKS],
-                                      limit=None
-                                      )
+        search_result = session.search(query='dummy_query',
+                                       types=[
+                                           const.ARTISTS,
+                                           const.ALBUMS,
+                                           const.PLAYLISTS,
+                                           const.TRACKS
+                                       ],
+                                       limit=None
+                                       )
         self.assertEqual(search_result.albums(), expected_albums)
         self.assertEqual(search_result.artists(), expected_artists)
         self.assertEqual(search_result.playlists(), expected_playlists)
@@ -271,31 +276,31 @@ class TestArtist(unittest.TestCase):
         self.request_mock.side_effect = [
             (
                 {
-                    "albums" : expected_albums_json[0:20]
+                    'albums' : expected_albums_json[0:20]
                 },
                 200
             ),
             (
                 {
-                    "albums" : expected_albums_json[20:40]
+                    'albums' : expected_albums_json[20:40]
                 },
                 200
             ),
             (
                 {
-                    "albums" : expected_albums_json[40:60]
+                    'albums' : expected_albums_json[40:60]
                 },
                 200
             ),
             (
                 {
-                    "albums" : expected_albums_json[60:80]
+                    'albums' : expected_albums_json[60:80]
                 },
                 200
             ),
             (
                 {
-                    "albums" : expected_albums_json[80:100]
+                    'albums' : expected_albums_json[80:100]
                 },
                 200
             )
@@ -313,13 +318,13 @@ class TestArtist(unittest.TestCase):
         self.request_mock.side_effect = [
             (
                 {
-                    "artists" : expected_artists_json[0:50]
+                    'artists' : expected_artists_json[0:50]
                 },
                 200
             ),
             (
                 {
-                    "artists" : expected_artists_json[50:100]
+                    'artists' : expected_artists_json[50:100]
                 },
                 200
             )
@@ -337,13 +342,13 @@ class TestArtist(unittest.TestCase):
         self.request_mock.side_effect = [
             (
                 {
-                    "tracks" : expected_tracks_json[0:50]
+                    'tracks' : expected_tracks_json[0:50]
                 },
                 200
             ),
             (
                 {
-                    "tracks" : expected_tracks_json[50:100]
+                    'tracks' : expected_tracks_json[50:100]
                 },
                 200
             )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -253,9 +253,46 @@ class TestArtist(unittest.TestCase):
         self.assertEqual(search_result.tracks(), expected_tracks)
 
     # Test get_albums
-    @unittest.skip('Not yet implemented')
     def test_get_albums(self):
-        self.assertTrue(False)
+        session = Session(TOKEN)
+        self.request_mock.side_effect = [
+            (
+                {
+                    "albums" : expected_albums_json[0:20]
+                },
+                200
+            ),
+            (
+                {
+                    "albums" : expected_albums_json[20:40]
+                },
+                200
+            ),
+            (
+                {
+                    "albums" : expected_albums_json[40:60]
+                },
+                200
+            ),
+            (
+                {
+                    "albums" : expected_albums_json[60:80]
+                },
+                200
+            ),
+            (
+                {
+                    "albums" : expected_albums_json[80:100]
+                },
+                200
+            )
+        ]
+        albums = session.get_albums(
+            list(
+                map(lambda x: x['id'], expected_albums_json)
+            )
+        )
+        self.assertEqual(albums, expected_albums)
 
     # Test get_artists
     @unittest.skip('Not yet implemented')


### PR DESCRIPTION
Dependent on #98 because of the refactor in paginate_get
- Add tests with mocking for Session class.
- Rename SEARCH_TYPE_X in Sesssion.search()